### PR TITLE
feat: create project from existing contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "clarinet"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "aes",
  "atty",
@@ -486,6 +486,7 @@ dependencies = [
  "pin-project",
  "rand 0.8.3",
  "regex",
+ "reqwest",
  "ring",
  "ripemd160",
  "rusty_v8",
@@ -512,6 +513,8 @@ dependencies = [
 [[package]]
 name = "clarity-repl"
 version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cbefbc19b99fa1f90df33b7477b34b0f118ce82c614684c0d903fae4844ba01"
 dependencies = [
  "ansi_term",
  "atty",
@@ -1685,6 +1688,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2105,6 +2121,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "net2"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2239,6 +2273,39 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "openssl"
+version = "0.10.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a61075b62a23fef5a29815de7536d940aa35ce96d18ce0cc5076272db678a577"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "313752393519e876837e09e1fa183ddef0be7735868dced3196f4472d536277f"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "os_str_bytes"
@@ -2404,6 +2471,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "pmutil"
@@ -2765,17 +2838,21 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "lazy_static",
  "log",
  "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "rustls",
  "serde",
+ "serde_json",
  "serde_urlencoded",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "url",
@@ -2923,6 +3000,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2942,6 +3029,29 @@ checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3670b1d2fdf6084d192bc71ead7aabe6c06aa2ea3fbd9cc3ac111fa5c2b1bd84"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3676258fd3cfe2c9a0ec99ce3038798d847ce3e4bb17746373eb9f0f1ac16339"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3775,6 +3885,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4030,6 +4150,12 @@ checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom 0.2.2",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbdbff6266a24120518560b5dc983096efb98462e51d0d68169895b237be3e5d"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ pin-project = "1.0.5"
 indexmap = { version = "1.6.1", features = ["serde"] }
 shell-escape = "0.1.5"
 tiny-hderive = "0.3.0"
+reqwest = { version = "0.11", features = ["json"] }
 
 [target.'cfg(windows)'.dependencies]
 fwdansi = "1.1.0"

--- a/src/generators/mod.rs
+++ b/src/generators/mod.rs
@@ -2,11 +2,13 @@ pub mod changes;
 mod contract;
 mod notebook;
 mod project;
+mod project_fork;
 
 pub use changes::{Changes, DirectoryCreation, FileCreation, TOMLEdition};
 use contract::GetChangesForNewContract;
 use notebook::GetChangesForNewNotebook;
 use project::GetChangesForNewProject;
+use project_fork::GetChangesForForkedProject;
 
 pub fn get_changes_for_new_project(project_path: String, project_name: String) -> Vec<Changes> {
     let mut command = GetChangesForNewProject::new(project_path, project_name);
@@ -20,5 +22,10 @@ pub fn get_changes_for_new_contract(project_path: String, contract_name: String)
 
 pub fn get_changes_for_new_notebook(project_path: String, notebook_name: String) -> Vec<Changes> {
     let command = GetChangesForNewNotebook::new(project_path, notebook_name);
+    command.run()
+}
+
+pub fn get_changes_for_forked_contract(project_path: String, project_name: String, contract_id: String) -> Vec<Changes> {
+    let mut command = GetChangesForForkedProject::new(project_path, project_name, contract_id);
     command.run()
 }

--- a/src/generators/project_fork.rs
+++ b/src/generators/project_fork.rs
@@ -1,0 +1,339 @@
+use crate::types::ContractConfig;
+use super::changes::{Changes, DirectoryCreation, FileCreation, TOMLEdition};
+use std::collections::HashMap;
+
+pub struct GetChangesForForkedProject {
+    project_path: String,
+    project_name: String,
+    contract_address: String,
+    contract_name: String,
+    changes: Vec<Changes>,
+}
+
+impl GetChangesForForkedProject {
+    pub fn new(project_path: String, project_name: String, contract_id: String) -> Self {
+        // get sender and contract name
+        let v: Vec<String> = contract_id.split('.').map(|s| s.to_string()).collect();
+        let contract_address = v[0].to_string();
+        let contract_name = v[1].to_string();
+
+        Self {
+            project_path,
+            project_name,
+            contract_address,
+            contract_name,
+            changes: vec![],
+        }
+    }
+
+    pub fn run(&mut self) -> Vec<Changes> {
+        self.create_root_directory();
+        self.create_contracts_directory();
+        self.create_settings_directory();
+        self.create_tests_directory();
+        self.create_clarinet_toml();
+        // self.create_environment_mainnet_toml();
+        // self.create_environment_testnet_toml();
+        self.create_environment_dev_toml();
+        self.create_vscode_directory();
+
+        self.create_forked_contract();
+        self.create_template_test();
+        self.index_contract_in_clarinet_toml();
+
+        self.changes.clone()
+    }
+
+    fn create_root_directory(&mut self) {
+        let dir = format!("{}/{}", self.project_path, self.project_name);
+        let change = DirectoryCreation {
+            comment: format!("Creating directory {}", self.project_name),
+            name: self.project_name.clone(),
+            path: dir,
+        };
+        self.changes.push(Changes::AddDirectory(change));
+    }
+
+    #[allow(dead_code)]
+    fn create_clients_directory(&mut self) {
+        self.changes
+            .push(self.get_changes_for_new_root_dir(format!("clients")));
+    }
+
+    fn create_contracts_directory(&mut self) {
+        self.changes
+            .push(self.get_changes_for_new_root_dir(format!("contracts")));
+    }
+
+    #[allow(dead_code)]
+    fn create_notebooks_directory(&mut self) {
+        self.changes
+            .push(self.get_changes_for_new_root_dir(format!("notebooks")));
+    }
+
+    #[allow(dead_code)]
+    fn create_scripts_directory(&mut self) {
+        self.changes
+            .push(self.get_changes_for_new_root_dir(format!("scripts")));
+    }
+
+    fn create_settings_directory(&mut self) {
+        self.changes
+            .push(self.get_changes_for_new_root_dir(format!("settings")));
+    }
+
+    fn create_tests_directory(&mut self) {
+        self.changes
+            .push(self.get_changes_for_new_root_dir(format!("tests")));
+    }
+
+    fn create_vscode_directory(&mut self) {
+        self.changes
+            .push(self.get_changes_for_new_root_dir(format!(".vscode")));
+        let content = format!(r#"
+{{
+    "deno.enable": true,
+}}
+"#
+        );
+        let name = format!("settings.json");
+        let path = format!("{}/{}/.vscode/{}", self.project_path, self.project_name, name);
+        let change = FileCreation {
+            comment: format!("Creating file {}/.vscode/{}", self.project_name, name),
+            name,
+            content,
+            path,
+        };
+        self.changes.push(Changes::AddFile(change));
+    }
+
+    fn create_clarinet_toml(&mut self) {
+        let content = format!(
+            r#"
+[project]
+name = "{}"
+
+[contracts]
+
+[notebooks]
+"#,
+            self.project_name
+        );
+        let name = format!("Clarinet.toml");
+        let path = format!("{}/{}/{}", self.project_path, self.project_name, name);
+        let change = FileCreation {
+            comment: format!("Creating file {}/{}", self.project_name, name),
+            name,
+            content,
+            path,
+        };
+        self.changes.push(Changes::AddFile(change));
+    }
+
+    #[allow(dead_code)]
+    fn create_environment_mainnet_toml(&mut self) {
+        let content = format!(
+            r#"[network]
+name = "mainnet"
+node_rpc_address = "http://stacks-node-api.blockstack.org:20443"
+"#
+        );
+        let name = format!("Mainnet.toml");
+        let path = format!(
+            "{}/{}/settings/{}",
+            self.project_path, self.project_name, name
+        );
+        let change = FileCreation {
+            comment: format!("Creating file {}/settings/{}", self.project_name, name),
+            name,
+            content,
+            path,
+        };
+        self.changes.push(Changes::AddFile(change));
+    }
+
+    #[allow(dead_code)]
+    fn create_environment_testnet_toml(&mut self) {
+        let content = format!(
+            r#"[network]
+name = "testnet"
+node_rpc_address = "http://xenon.blockstack.org:20443"
+"#
+        );
+        let name = format!("Testnet.toml");
+        let path = format!(
+            "{}/{}/settings/{}",
+            self.project_path, self.project_name, name
+        );
+        let change = FileCreation {
+            comment: format!("Creating file {}/settings/{}", self.project_name, name),
+            name,
+            content,
+            path,
+        };
+        self.changes.push(Changes::AddFile(change));
+    }
+
+    fn create_environment_dev_toml(&mut self) {
+        let content = format!(
+            r#"[network]
+name = "Development"
+
+[accounts.deployer]
+mnemonic = "fetch outside black test wash cover just actual execute nice door want airport betray quantum stamp fish act pen trust portion fatigue scissors vague"
+balance = 1_000_000
+
+[accounts.wallet_1]
+mnemonic = "spoil sock coyote include verify comic jacket gain beauty tank flush victory illness edge reveal shallow plug hobby usual juice harsh pact wreck eight"
+balance = 1_000_000
+
+[accounts.wallet_2]
+mnemonic = "arrange scale orient half ugly kid bike twin magnet joke hurt fiber ethics super receive version wreck media fluid much abstract reward street alter"
+balance = 1_000_000
+
+[accounts.wallet_3]
+mnemonic = "glide clown kitchen picnic basket hidden asset beyond kid plug carbon talent drama wet pet rhythm hero nest purity baby bicycle ghost sponsor dragon"
+balance = 1_000_000
+
+[accounts.wallet_4]
+mnemonic = "pulp when detect fun unaware reduce promote tank success lecture cool cheese object amazing hunt plug wing month hello tunnel detect connect floor brush"
+balance = 1_000_000
+
+[accounts.wallet_5]
+mnemonic = "replace swing shove congress smoke banana tired term blanket nominee leave club myself swing egg virus answer bulk useful start decrease family energy february"
+balance = 1_000_000
+
+[accounts.wallet_6]
+mnemonic = "apology together shy taxi glare struggle hip camp engage lion possible during squeeze hen exotic marriage misery kiwi once quiz enough exhibit immense tooth"
+balance = 1_000_000
+
+[accounts.wallet_7]
+mnemonic = "antenna bitter find rely gadget father exact excuse cross easy elbow alcohol injury loud silk bird crime cabbage winter fit wide screen update october"
+balance = 1_000_000
+
+[accounts.wallet_8]
+mnemonic = "east load echo merit ignore hip tag obvious truly adjust smart panther deer aisle north hotel process frown lock property catch bless notice topple"
+balance = 1_000_000
+
+[accounts.wallet_9]
+mnemonic = "market ocean tortoise venue vivid coach machine category conduct enable insect jump fog file test core book chaos crucial burst version curious prosper fever"
+balance = 1_000_000
+"#
+        );
+        let name = format!("Development.toml");
+        let path = format!(
+            "{}/{}/settings/{}",
+            self.project_path, self.project_name, name
+        );
+        let change = FileCreation {
+            comment: format!("Creating file {}/settings/{}", self.project_name, name),
+            name,
+            content,
+            path,
+        };
+        self.changes.push(Changes::AddFile(change));
+    }
+
+    fn get_changes_for_new_root_dir(&self, name: String) -> Changes {
+        let dir = format!("{}/{}", self.project_name, name);
+        let change = DirectoryCreation {
+            comment: format!("Creating directory {}/{}", self.project_name, name),
+            name,
+            path: dir,
+        };
+        Changes::AddDirectory(change)
+    }
+
+
+    #[tokio::main]
+    async fn create_forked_contract(&mut self) {
+        // download file
+        #[derive(Deserialize, Debug)]
+        struct Contract {
+            source: String,
+            publish_height: u32,
+        }
+
+        let request_url = format!(
+            "https://stacks-node-api.mainnet.stacks.co/v2/contracts/source/{addr}/{name}?proof=0",
+            addr = self.contract_address,
+            name = self.contract_name
+        );
+        let response: Contract = reqwest::get(&request_url)
+            .await.unwrap()
+            .json()
+            .await.unwrap();
+        let content = response.source;
+
+        let name = format!("{}.clar", self.contract_name);
+        let path = format!("{}/{}/contracts/{}", self.project_path, self.project_name, name);
+        let change = FileCreation {
+            comment: format!("Creating file contracts/{}", name),
+            name,
+            content,
+            path,
+        };
+        self.changes.push(Changes::AddFile(change));
+    }
+
+    fn create_template_test(&mut self) {
+        let content = format!(
+            r#"
+import {{ Clarinet, Tx, Chain, Account, types }} from 'https://deno.land/x/clarinet@v0.5.2/index.ts';
+import {{ assertEquals }} from 'https://deno.land/std@0.90.0/testing/asserts.ts';
+
+Clarinet.test({{
+    name: "Ensure that <...>",
+    async fn(chain: Chain, accounts: Map<string, Account>) {{
+        let block = chain.mineBlock([
+            /* 
+             * Add transactions with: 
+             * Tx.contractCall(...)
+            */
+        ]);
+        assertEquals(block.receipts.length, 0);
+        assertEquals(block.height, 2);
+
+        block = chain.mineBlock([
+            /* 
+             * Add transactions with: 
+             * Tx.contractCall(...)
+            */
+        ]);
+        assertEquals(block.receipts.length, 0);
+        assertEquals(block.height, 3);
+    }},
+}});
+"#
+        );
+        let name = format!("{}_test.ts", self.contract_name);
+        let path = format!("{}/{}/tests/{}", self.project_path, self.project_name, name);
+        let change = FileCreation {
+            comment: format!("Creating file tests/{}", name),
+            name,
+            content,
+            path,
+        };
+        self.changes.push(Changes::AddFile(change));
+    }
+
+    fn index_contract_in_clarinet_toml(&mut self) {
+        let contract_file_name = format!("{}.clar", self.contract_name);
+        let path = format!("{}/{}/Clarinet.toml", self.project_path, self.project_name);
+
+        let contract_config = ContractConfig {
+            depends_on: vec![],
+            path: format!("{}/{}/contracts/{}", self.project_path, self.project_name, contract_file_name),
+        };
+        let mut contracts_to_add = HashMap::new();
+        contracts_to_add.insert(self.contract_name.clone(), contract_config);
+
+        let change = TOMLEdition {
+            comment: format!("Adding contract {} to Clarinet.toml", self.contract_name),
+            path,
+            contracts_to_add,
+            notebooks_to_add: HashMap::new(),
+        };
+        self.changes.push(Changes::EditTOML(change));
+    }
+}


### PR DESCRIPTION
Adds a new command to generate a fresh project from an existing, deployed contract on the mainnet:

```
clarinet fork my-project SP162D87CY84QVVCMJKNKGHC7GGXFGA0TAR9D0XJW.puzzled-gold-stork
```